### PR TITLE
DSND-2870: Improve logging and published_at timestamp format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-logging</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
@@ -302,11 +306,10 @@
 				<version>${jib-maven-plugin.version}</version>
 				<configuration>
 					<from>
-						<image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-corretto-build-21:latest</image>
+						<image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-corretto-runtime-21:latest</image>
 					</from>
 					<to>
-						//Once the pipeline is moved to shared services need to update this to image reference from shared services
-						<image>169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/registers-data-api:latest</image>
+						<image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/registers-data-api:latest</image>
 					</to>
 				</configuration>
 			</plugin>

--- a/src/main/java/uk/gov/companieshouse/registers/RegistersApplication.java
+++ b/src/main/java/uk/gov/companieshouse/registers/RegistersApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class RegistersApplication {
 
-	public static final String APPLICATION_NAME_SPACE = "registers-data-api";
+	public static final String NAMESPACE = "registers-data-api";
 
 	public static void main(String[] args) {
 		SpringApplication.run(RegistersApplication.class, args);

--- a/src/main/java/uk/gov/companieshouse/registers/config/Config.java
+++ b/src/main/java/uk/gov/companieshouse/registers/config/Config.java
@@ -5,34 +5,27 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.function.Supplier;
-
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
-import uk.gov.companieshouse.registers.util.*;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
-
-import static uk.gov.companieshouse.registers.RegistersApplication.APPLICATION_NAME_SPACE;
+import uk.gov.companieshouse.registers.util.EmptyFieldDeserializer;
+import uk.gov.companieshouse.registers.util.LocalDateDeSerializer;
+import uk.gov.companieshouse.registers.util.LocalDateSerializer;
+import uk.gov.companieshouse.registers.util.RegistersReadConverter;
+import uk.gov.companieshouse.registers.util.RegistersWriteConverter;
 
 @Configuration
 public class Config {
 
     @Bean
-    public Logger logger() {
-        return LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
-    }
-
-    @Bean
-    public Supplier<String> offsetDateTimeGenerator() {
-        return () -> String.valueOf(OffsetDateTime.now());
+    public Supplier<Instant> instantSupplier() {
+        return Instant::now;
     }
 
     /**
@@ -43,7 +36,8 @@ public class Config {
     @Bean
     public MongoCustomConversions mongoCustomConversions() {
         ObjectMapper objectMapper = mongoDbObjectMapper();
-        return new MongoCustomConversions(List.of(new RegistersWriteConverter(objectMapper), new RegistersReadConverter(objectMapper)));
+        return new MongoCustomConversions(
+                List.of(new RegistersWriteConverter(objectMapper), new RegistersReadConverter(objectMapper)));
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/registers/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/registers/config/ExceptionHandlerConfig.java
@@ -1,10 +1,11 @@
 package uk.gov.companieshouse.registers.config;
 
+import static uk.gov.companieshouse.registers.RegistersApplication.NAMESPACE;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,31 +13,28 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.registers.exception.BadRequestException;
 import uk.gov.companieshouse.registers.exception.ServiceUnavailableException;
-import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.registers.logging.DataMapHolder;
 
 @ControllerAdvice
 public class ExceptionHandlerConfig {
-    private final Logger logger;
 
-    @Autowired
-    public ExceptionHandlerConfig(Logger logger) {
-        this.logger = logger;
-    }
+    private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
 
     /**
-     * BadRequestException exception handler.
-    * Thrown when data is given in the wrong format.
-    *
-    * @param ex      exception to handle.
-    * @param request request.
-    * @return error response to return.
-    */
+     * BadRequestException exception handler. Thrown when data is given in the wrong format.
+     *
+     * @param ex      exception to handle.
+     * @param request request.
+     * @return error response to return.
+     */
     @ExceptionHandler(value = {BadRequestException.class, DateTimeParseException.class,
-        HttpMessageNotReadableException.class})
+            HttpMessageNotReadableException.class})
     public ResponseEntity<Object> handleBadRequestException(Exception ex, WebRequest request) {
-        logger.error(String.format("Bad request, response code: %s", HttpStatus.BAD_REQUEST), ex);
+        LOGGER.error("Bad request, response code: %s".formatted(HttpStatus.BAD_REQUEST), ex, DataMapHolder.getLogMap());
 
         Map<String, Object> responseBody = new LinkedHashMap<>();
         responseBody.put("timestamp", LocalDateTime.now());
@@ -46,8 +44,7 @@ public class ExceptionHandlerConfig {
     }
 
     /**
-     * ServiceUnavailableException exception handler.
-     * To be thrown when there are connection issues.
+     * ServiceUnavailableException exception handler. To be thrown when there are connection issues.
      *
      * @param ex      exception to handle.
      * @param request request.
@@ -55,9 +52,9 @@ public class ExceptionHandlerConfig {
      */
     @ExceptionHandler(value = {ServiceUnavailableException.class, DataAccessException.class})
     public ResponseEntity<Object> handleServiceUnavailableException(Exception ex,
-                                                                    WebRequest request) {
-        logger.error(String.format("Service unavailable, response code: %s",
-                HttpStatus.SERVICE_UNAVAILABLE), ex);
+            WebRequest request) {
+        LOGGER.info("Service unavailable, response code: %s".formatted(HttpStatus.SERVICE_UNAVAILABLE),
+                DataMapHolder.getLogMap());
 
         Map<String, Object> responseBody = new LinkedHashMap<>();
         responseBody.put("timestamp", LocalDateTime.now());

--- a/src/main/java/uk/gov/companieshouse/registers/config/MongoDbConfig.java
+++ b/src/main/java/uk/gov/companieshouse/registers/config/MongoDbConfig.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.registers.config;
 
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
@@ -10,9 +9,11 @@ import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 @Configuration
 public class MongoDbConfig implements InitializingBean {
 
-    @Autowired
-    @Lazy
-    private MappingMongoConverter mappingMongoConverter;
+    private final MappingMongoConverter mappingMongoConverter;
+
+    public MongoDbConfig(@Lazy MappingMongoConverter mappingMongoConverter) {
+        this.mappingMongoConverter = mappingMongoConverter;
+    }
 
     // Remove _class field from data
     @Override

--- a/src/main/java/uk/gov/companieshouse/registers/config/WebSecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/registers/config/WebSecurityConfig.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.registers.config;
 
-import java.util.Arrays;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,11 +11,10 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.csrf.CsrfFilter;
 import uk.gov.companieshouse.api.filter.CustomCorsFilter;
 import uk.gov.companieshouse.registers.service.AuthenticationFilter;
-import uk.gov.companieshouse.logging.Logger;
 
 @Configuration
 @EnableWebSecurity
@@ -27,7 +25,7 @@ public class WebSecurityConfig {
      * Configure Http Security.
      */
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, Logger logger) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(AbstractHttpConfigurer::disable)
@@ -35,7 +33,7 @@ public class WebSecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .addFilterAt(new AuthenticationFilter(logger), BasicAuthenticationFilter.class)
+                .addFilterAt(new AuthenticationFilter(), BasicAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
         return http.build();
     }
@@ -53,6 +51,6 @@ public class WebSecurityConfig {
      */
     @Bean
     public List<String> externalMethods() {
-        return Arrays.asList(HttpMethod.GET.name());
+        return List.of(HttpMethod.GET.name());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/registers/controller/RegistersController.java
+++ b/src/main/java/uk/gov/companieshouse/registers/controller/RegistersController.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.registers.controller;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import static uk.gov.companieshouse.registers.RegistersApplication.NAMESPACE;
+
+import java.util.Optional;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -8,66 +10,63 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.registers.CompanyRegister;
 import uk.gov.companieshouse.api.registers.InternalRegisters;
-import uk.gov.companieshouse.registers.model.CompanyRegistersDocument;
-import uk.gov.companieshouse.registers.service.RegistersService;
-import uk.gov.companieshouse.registers.model.ServiceStatus;
 import uk.gov.companieshouse.logging.Logger;
-
-import java.util.Optional;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.registers.logging.DataMapHolder;
+import uk.gov.companieshouse.registers.model.CompanyRegistersDocument;
+import uk.gov.companieshouse.registers.model.ServiceStatus;
+import uk.gov.companieshouse.registers.service.RegistersService;
 
 @RestController
 public class RegistersController {
 
-    @Autowired
-    private Logger logger;
+    private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
 
-    @Autowired
-    private RegistersService service;
+    private final RegistersService service;
+
+    public RegistersController(RegistersService service) {
+        this.service = service;
+    }
 
     @GetMapping("/company/{company_number}/registers")
-    public ResponseEntity<CompanyRegister> companyRegistersGet(
-            @RequestHeader("x-request-id") String contextId,
-            @PathVariable("company_number") String companyNumber) {
-        logger.info(String.format("Getting company registers for company number %s", companyNumber));
+    public ResponseEntity<CompanyRegister> companyRegistersGet(@PathVariable("company_number") String companyNumber) {
+        DataMapHolder.get().companyNumber(companyNumber);
+        LOGGER.info("Getting company registers", DataMapHolder.getLogMap());
 
         Optional<CompanyRegistersDocument> document = service.getCompanyRegisters(companyNumber);
 
         return document.map(companyRegistersDocument -> ResponseEntity.ok().body(companyRegistersDocument.getData())).
                 orElseGet(() -> ResponseEntity.notFound().build());
-
     }
 
     @PutMapping("/company/{company_number}/registers")
     public ResponseEntity<Void> companyRegistersUpsert(
-            @RequestHeader("x-request-id") String contextId,
             @PathVariable("company_number") String companyNumber,
             @RequestBody InternalRegisters requestBody) {
-        logger.info(String.format(
-                "Processing company registers information for company number %s",
-                companyNumber));
+        DataMapHolder.get().companyNumber(companyNumber);
+        LOGGER.info("Processing company registers upsert", DataMapHolder.getLogMap());
 
-        ServiceStatus serviceStatus = service.upsertCompanyRegisters(contextId, companyNumber, requestBody);
+        ServiceStatus serviceStatus = service.upsertCompanyRegisters(companyNumber, requestBody);
 
         if (serviceStatus.equals(ServiceStatus.SERVER_ERROR)) {
             return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
         } else if (serviceStatus.equals(ServiceStatus.CLIENT_ERROR)) {
             return ResponseEntity.status(HttpStatus.CONFLICT).build();
-        }else {
+        } else {
             return ResponseEntity.ok().build();
         }
     }
 
     @DeleteMapping("/company/{company_number}/registers")
     public ResponseEntity<CompanyRegistersDocument> companyRegistersDelete(
-            @RequestHeader("x-request-id") String contextId,
             @PathVariable("company_number") String companyNumber) {
-        logger.info(String.format("Deleting company registers for company number %s", companyNumber));
+        DataMapHolder.get().companyNumber(companyNumber);
+        LOGGER.info("Deleting company registers", DataMapHolder.getLogMap());
 
-        ServiceStatus serviceStatus = service.deleteCompanyRegisters(contextId, companyNumber);
+        ServiceStatus serviceStatus = service.deleteCompanyRegisters(companyNumber);
 
         if (serviceStatus.equals(ServiceStatus.SERVER_ERROR)) {
             return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();

--- a/src/main/java/uk/gov/companieshouse/registers/controller/RegistersController.java
+++ b/src/main/java/uk/gov/companieshouse/registers/controller/RegistersController.java
@@ -47,7 +47,7 @@ public class RegistersController {
             @PathVariable("company_number") String companyNumber,
             @RequestBody InternalRegisters requestBody) {
         DataMapHolder.get().companyNumber(companyNumber);
-        LOGGER.info("Processing company registers upsert", DataMapHolder.getLogMap());
+        LOGGER.info("Upserting company registers", DataMapHolder.getLogMap());
 
         ServiceStatus serviceStatus = service.upsertCompanyRegisters(companyNumber, requestBody);
 

--- a/src/main/java/uk/gov/companieshouse/registers/logging/DataMapHolder.java
+++ b/src/main/java/uk/gov/companieshouse/registers/logging/DataMapHolder.java
@@ -1,0 +1,35 @@
+package uk.gov.companieshouse.registers.logging;
+
+import java.util.Map;
+import uk.gov.companieshouse.logging.util.DataMap.Builder;
+
+public class DataMapHolder {
+
+    private static final ThreadLocal<Builder> DATAMAP_BUILDER
+            = ThreadLocal.withInitial(() -> new Builder().requestId("uninitialised"));
+
+    public static void initialise(String requestId) {
+        DATAMAP_BUILDER.get().requestId(requestId);
+    }
+
+    private DataMapHolder() {
+    }
+
+    public static void clear() {
+        DATAMAP_BUILDER.remove();
+    }
+
+    public static Builder get() {
+        return DATAMAP_BUILDER.get();
+    }
+
+    public static Map<String, Object> getLogMap() {
+        return DATAMAP_BUILDER.get()
+                .build()
+                .getLogMap();
+    }
+
+    public static String getRequestId() {
+        return (String) getLogMap().get("request_id");
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/registers/logging/RequestLoggingFilter.java
+++ b/src/main/java/uk/gov/companieshouse/registers/logging/RequestLoggingFilter.java
@@ -1,0 +1,54 @@
+package uk.gov.companieshouse.registers.logging;
+
+
+import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
+import static uk.gov.companieshouse.logging.util.LogContextProperties.REQUEST_ID;
+import static uk.gov.companieshouse.registers.RegistersApplication.NAMESPACE;
+
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.logging.util.RequestLogger;
+import uk.gov.companieshouse.registers.exception.InternalServerErrorException;
+import uk.gov.companieshouse.registers.exception.ServiceUnavailableException;
+
+@Component
+@Order(value = HIGHEST_PRECEDENCE)
+public class RequestLoggingFilter extends OncePerRequestFilter implements RequestLogger {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
+
+    @Override
+    protected void doFilterInternal(@Nonnull HttpServletRequest request,
+            @Nonnull HttpServletResponse response,
+            @Nonnull FilterChain filterChain) throws ServletException, IOException {
+        logStartRequestProcessing(request, LOGGER);
+        DataMapHolder.initialise(Optional
+                .ofNullable(request.getHeader(REQUEST_ID.value()))
+                .orElse(UUID.randomUUID().toString()));
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ServiceUnavailableException | InternalServerErrorException ex) {
+            LOGGER.info("Recoverable exception: %s".formatted(Arrays.toString(ex.getStackTrace())),
+                    DataMapHolder.getLogMap());
+            throw ex;
+        } catch (Exception ex) {
+            LOGGER.error(ex.getMessage(), ex, DataMapHolder.getLogMap());
+            throw ex;
+        } finally {
+            logEndRequestProcessing(request, response, LOGGER);
+            DataMapHolder.clear();
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/registers/model/CompanyRegistersDocument.java
+++ b/src/main/java/uk/gov/companieshouse/registers/model/CompanyRegistersDocument.java
@@ -1,11 +1,10 @@
 package uk.gov.companieshouse.registers.model;
 
+import java.util.Objects;
+import javax.persistence.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.companieshouse.api.registers.CompanyRegister;
-
-import javax.persistence.Id;
-import java.util.Objects;
 
 @Document(collection = "company_registers")
 public class CompanyRegistersDocument {

--- a/src/main/java/uk/gov/companieshouse/registers/model/Created.java
+++ b/src/main/java/uk/gov/companieshouse/registers/model/Created.java
@@ -1,9 +1,8 @@
 package uk.gov.companieshouse.registers.model;
 
+import java.time.LocalDateTime;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalDateTime;
 
 public class Created {
     @Field("updated_at")

--- a/src/main/java/uk/gov/companieshouse/registers/model/ResourceChangedRequest.java
+++ b/src/main/java/uk/gov/companieshouse/registers/model/ResourceChangedRequest.java
@@ -1,25 +1,5 @@
 package uk.gov.companieshouse.registers.model;
 
-import java.util.Objects;
+public record ResourceChangedRequest(String companyNumber, Object registersData, Boolean isDelete) {
 
-public record ResourceChangedRequest(String contextId, String companyNumber, Object registersData, Boolean isDelete) {
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ResourceChangedRequest that = (ResourceChangedRequest) o;
-        return Objects.equals(contextId, that.contextId) &&
-                Objects.equals(companyNumber, that.companyNumber) &&
-                Objects.equals(registersData, that.registersData) &&
-                Objects.equals(isDelete, that.isDelete);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(contextId, companyNumber, registersData, isDelete);
-    }
 }

--- a/src/main/java/uk/gov/companieshouse/registers/service/RegistersService.java
+++ b/src/main/java/uk/gov/companieshouse/registers/service/RegistersService.java
@@ -6,7 +6,7 @@ import uk.gov.companieshouse.registers.model.CompanyRegistersDocument;
 import uk.gov.companieshouse.registers.model.ServiceStatus;
 
 public interface RegistersService {
-    ServiceStatus upsertCompanyRegisters(String contextId, String companyNumber, InternalRegisters requestBody);
+    ServiceStatus upsertCompanyRegisters(String companyNumber, InternalRegisters requestBody);
     Optional<CompanyRegistersDocument> getCompanyRegisters(String companyNumber);
-    ServiceStatus deleteCompanyRegisters(String contextId, String companyNumber);
+    ServiceStatus deleteCompanyRegisters(String companyNumber);
 }

--- a/src/main/java/uk/gov/companieshouse/registers/service/RegistersServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/registers/service/RegistersServiceImpl.java
@@ -63,12 +63,12 @@ public class RegistersServiceImpl implements RegistersService {
 
                 // save the document before calling resource-changed
                 repository.save(document);
-                LOGGER.info("Company registers updated in MongoDb", DataMapHolder.getLogMap());
+                LOGGER.info("Company registers upserted in MongoDb", DataMapHolder.getLogMap());
 
                 // call resource-changed after saving the document
                 ServiceStatus serviceStatus = registersApiService.invokeChsKafkaApi(
                         new ResourceChangedRequest(companyNumber, null, false));
-                LOGGER.info("ChsKafka api CHANGED invoked", DataMapHolder.getLogMap());
+                LOGGER.info("ChsKafka api CHANGED invoked successfully", DataMapHolder.getLogMap());
                 return serviceStatus;
             } else {
                 LOGGER.error("Record not persisted as it is not the latest record", DataMapHolder.getLogMap());

--- a/src/main/java/uk/gov/companieshouse/registers/service/RegistersServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/registers/service/RegistersServiceImpl.java
@@ -1,5 +1,8 @@
 package uk.gov.companieshouse.registers.service;
 
+
+import static uk.gov.companieshouse.registers.RegistersApplication.NAMESPACE;
+
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -8,33 +11,36 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.registers.InternalRegisters;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.registers.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.registers.logging.DataMapHolder;
 import uk.gov.companieshouse.registers.model.CompanyRegistersDocument;
 import uk.gov.companieshouse.registers.model.Created;
 import uk.gov.companieshouse.registers.model.ResourceChangedRequest;
 import uk.gov.companieshouse.registers.model.ServiceStatus;
 import uk.gov.companieshouse.registers.util.RegistersMapper;
-import uk.gov.companieshouse.logging.Logger;
 
 @Service
 public class RegistersServiceImpl implements RegistersService {
 
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS").withZone(ZoneId.of("Z"));
+    private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS")
+            .withZone(ZoneId.of("Z"));
 
-    private final Logger logger;
     private final RegistersRepository repository;
     private final RegistersMapper mapper;
     private final RegistersApiService registersApiService;
 
-    public RegistersServiceImpl(Logger logger, RegistersRepository repository, RegistersMapper mapper, RegistersApiService registersApiService) {
-        this.logger = logger;
+    public RegistersServiceImpl(RegistersRepository repository, RegistersMapper mapper,
+            RegistersApiService registersApiService) {
         this.repository = repository;
         this.mapper = mapper;
         this.registersApiService = registersApiService;
     }
 
     @Override
-    public ServiceStatus upsertCompanyRegisters(String contextId, String companyNumber, InternalRegisters requestBody) {
+    public ServiceStatus upsertCompanyRegisters(String companyNumber, InternalRegisters requestBody) {
         try {
             Optional<CompanyRegistersDocument> existingDocument = repository.findById(companyNumber);
 
@@ -46,7 +52,8 @@ public class RegistersServiceImpl implements RegistersService {
                     !requestBody.getInternalData().getDeltaAt()
                             .isBefore(ZonedDateTime.parse(existingDocument.get().getDeltaAt(), FORMATTER)
                                     .toOffsetDateTime())) {
-                CompanyRegistersDocument document = mapper.map(companyNumber, existingDocument.orElse(null), requestBody);
+                CompanyRegistersDocument document = mapper.map(companyNumber, existingDocument.orElse(null),
+                        requestBody);
 
                 // If a document already exists and it has a created field, then reuse it
                 // otherwise, set it to the delta's updated_at field
@@ -56,24 +63,22 @@ public class RegistersServiceImpl implements RegistersService {
 
                 // save the document before calling resource-changed
                 repository.save(document);
-                logger.info(String.format("Company registers for company number: %s updated in MongoDb for context id: %s",
-                        companyNumber,
-                        contextId));
+                LOGGER.info("Company registers updated in MongoDb", DataMapHolder.getLogMap());
 
                 // call resource-changed after saving the document
-                ServiceStatus serviceStatus = registersApiService.invokeChsKafkaApi(new ResourceChangedRequest(contextId, companyNumber, null, false));
-                logger.info(String.format("ChsKafka api CHANGED invoked for context id: %s and company number: %s response status: %s",
-                        contextId, companyNumber, serviceStatus));
+                ServiceStatus serviceStatus = registersApiService.invokeChsKafkaApi(
+                        new ResourceChangedRequest(companyNumber, null, false));
+                LOGGER.info("ChsKafka api CHANGED invoked", DataMapHolder.getLogMap());
                 return serviceStatus;
             } else {
-                logger.info(String.format("Record for company %s not persisted as it is not the latest record.", companyNumber));
+                LOGGER.error("Record not persisted as it is not the latest record", DataMapHolder.getLogMap());
                 return ServiceStatus.CLIENT_ERROR;
             }
         } catch (IllegalArgumentException ex) {
-            logger.error("Illegal argument exception caught when processing upsert", ex);
+            LOGGER.error("Illegal argument exception caught when processing upsert", ex, DataMapHolder.getLogMap());
             return ServiceStatus.SERVER_ERROR;
         } catch (DataAccessException ex) {
-            logger.error("Error connecting to MongoDB");
+            LOGGER.error("Error connecting to MongoDB", ex, DataMapHolder.getLogMap());
             return ServiceStatus.SERVER_ERROR;
         }
     }
@@ -83,34 +88,34 @@ public class RegistersServiceImpl implements RegistersService {
         try {
             return repository.findById(companyNumber);
         } catch (DataAccessException ex) {
-            logger.error("Failed to connect to MongoDb", ex);
+            LOGGER.error("Failed to connect to MongoDb", ex, DataMapHolder.getLogMap());
             throw new ServiceUnavailableException("Data access exception thrown when calling Mongo Repository");
         }
     }
 
     @Override
-    public ServiceStatus deleteCompanyRegisters(String contextId, String companyNumber) {
+    public ServiceStatus deleteCompanyRegisters(String companyNumber) {
         try {
             Optional<CompanyRegistersDocument> document = getCompanyRegisters(companyNumber);
             if (document.isEmpty()) {
-                logger.error(String.format("Company registers do not exist for company number %s", companyNumber));
+                LOGGER.info("Company registers do not exist", DataMapHolder.getLogMap());
                 return ServiceStatus.CLIENT_ERROR;
             }
 
             ServiceStatus serviceStatus = registersApiService.invokeChsKafkaApi(
-                    new ResourceChangedRequest(contextId, companyNumber, document.get().getData(), true));
-            logger.info(String.format("ChsKafka api DELETED invoked successfully for context id: %s and company number: %s", contextId, companyNumber));
+                    new ResourceChangedRequest(companyNumber, document.get().getData(), true));
+            LOGGER.info("ChsKafka api DELETED invoked successfully", DataMapHolder.getLogMap());
 
             if (ServiceStatus.SUCCESS.equals(serviceStatus)) {
                 repository.deleteById(companyNumber);
-                logger.info(String.format("Company registers for company number: %s deleted in MongoDb for context id: %s", companyNumber, contextId));
+                LOGGER.info("Company registers deleted in MongoDb", DataMapHolder.getLogMap());
             }
             return serviceStatus;
         } catch (IllegalArgumentException ex) {
-            logger.error("Error calling chs-kafka-api");
+            LOGGER.error("Error calling chs-kafka-api", ex, DataMapHolder.getLogMap());
             return ServiceStatus.SERVER_ERROR;
         } catch (DataAccessException ex) {
-            logger.error("Error connecting to MongoDB");
+            LOGGER.error("Error connecting to MongoDB", ex, DataMapHolder.getLogMap());
             return ServiceStatus.SERVER_ERROR;
         }
     }

--- a/src/main/java/uk/gov/companieshouse/registers/util/EmptyFieldDeserializer.java
+++ b/src/main/java/uk/gov/companieshouse/registers/util/EmptyFieldDeserializer.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-
 import java.io.IOException;
 
 public class EmptyFieldDeserializer  extends JsonDeserializer<String> {

--- a/src/main/java/uk/gov/companieshouse/registers/util/LocalDateDeSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/registers/util/LocalDateDeSerializer.java
@@ -1,21 +1,24 @@
 package uk.gov.companieshouse.registers.util;
 
+
+import static java.time.ZoneOffset.UTC;
+import static uk.gov.companieshouse.registers.RegistersApplication.NAMESPACE;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import org.springframework.beans.factory.annotation.Autowired;
-import uk.gov.companieshouse.registers.exception.BadRequestException;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.registers.exception.BadRequestException;
+import uk.gov.companieshouse.registers.logging.DataMapHolder;
 
 public class LocalDateDeSerializer extends JsonDeserializer<LocalDate> {
 
-    @Autowired
-    private Logger logger;
+    private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
 
     @Override
     public LocalDate deserialize(JsonParser jsonParser, DeserializationContext
@@ -34,9 +37,9 @@ public class LocalDateDeSerializer extends JsonDeserializer<LocalDate> {
              */
             return dateNode.textValue() != null ?
                     LocalDate.parse(dateNode.textValue(), dateTimeFormatter) :
-                    LocalDate.ofInstant(Instant.ofEpochMilli(dateNode.get("$numberLong").asLong()), ZoneId.systemDefault());
+                    LocalDate.ofInstant(Instant.ofEpochMilli(dateNode.get("$numberLong").asLong()), UTC);
         } catch (Exception exception) {
-            logger.error("Deserialization failed.", exception);
+            LOGGER.error("Deserialization failed", exception, DataMapHolder.getLogMap());
             throw new BadRequestException(exception.getMessage());
         }
     }

--- a/src/main/java/uk/gov/companieshouse/registers/util/RegistersMapper.java
+++ b/src/main/java/uk/gov/companieshouse/registers/util/RegistersMapper.java
@@ -1,16 +1,17 @@
 package uk.gov.companieshouse.registers.util;
 
-import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.GenerateEtagUtil;
-import uk.gov.companieshouse.api.registers.*;
-import uk.gov.companieshouse.registers.model.CompanyRegistersDocument;
-import uk.gov.companieshouse.registers.model.Updated;
+import static uk.gov.companieshouse.api.registers.CompanyRegister.KindEnum.REGISTERS;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Optional;
-
-import static uk.gov.companieshouse.api.registers.CompanyRegister.KindEnum.REGISTERS;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.GenerateEtagUtil;
+import uk.gov.companieshouse.api.registers.CompanyRegister;
+import uk.gov.companieshouse.api.registers.InternalRegisters;
+import uk.gov.companieshouse.api.registers.LinksType;
+import uk.gov.companieshouse.api.registers.Registers;
+import uk.gov.companieshouse.registers.model.CompanyRegistersDocument;
+import uk.gov.companieshouse.registers.model.Updated;
 
 @Component
 public class RegistersMapper {
@@ -18,7 +19,7 @@ public class RegistersMapper {
     private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS");
 
     public CompanyRegistersDocument map(String companyNumber, CompanyRegistersDocument existingDocument,
-                                        InternalRegisters requestBody) {
+            InternalRegisters requestBody) {
         return new CompanyRegistersDocument()
                 .setId(companyNumber)
                 .setData(new CompanyRegister()

--- a/src/main/java/uk/gov/companieshouse/registers/util/ResourceChangedRequestMapper.java
+++ b/src/main/java/uk/gov/companieshouse/registers/util/ResourceChangedRequestMapper.java
@@ -1,37 +1,46 @@
 package uk.gov.companieshouse.registers.util;
 
-import java.util.function.Supplier;
+import static java.time.ZoneOffset.UTC;
+import static uk.gov.companieshouse.registers.RegistersApplication.NAMESPACE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.function.Supplier;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.registers.exception.InternalServerErrorException;
+import uk.gov.companieshouse.registers.logging.DataMapHolder;
 import uk.gov.companieshouse.registers.model.ResourceChangedRequest;
 
 @Component
 public class ResourceChangedRequestMapper {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
     private static final String SERDES_ERROR_MSG = "Serialisation/deserialisation failed when mapping deleted data";
-    private final Supplier<String> timestampGenerator;
-    private final ObjectMapper objectMapper;
-    private final Logger logger;
+    private static final DateTimeFormatter PUBLISHED_AT_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss").withZone(UTC);
 
-    public ResourceChangedRequestMapper(Supplier<String> timestampGenerator, ObjectMapper objectMapper, Logger logger) {
+    private final Supplier<Instant> timestampGenerator;
+    private final ObjectMapper objectMapper;
+
+    public ResourceChangedRequestMapper(Supplier<Instant> timestampGenerator, ObjectMapper objectMapper) {
         this.timestampGenerator = timestampGenerator;
         this.objectMapper = objectMapper;
-        this.logger = logger;
     }
 
     public ChangedResource mapChangedResource(ResourceChangedRequest request) {
-        ChangedResourceEvent event = new ChangedResourceEvent().publishedAt(this.timestampGenerator.get());
+        ChangedResourceEvent event = new ChangedResourceEvent()
+                .publishedAt(PUBLISHED_AT_FORMATTER.format(timestampGenerator.get()));
         ChangedResource changedResource = new ChangedResource()
                 .resourceUri(String.format("company/%s/registers", request.companyNumber()))
                 .resourceKind("registers")
                 .event(event)
-                .contextId(request.contextId());
+                .contextId(DataMapHolder.getRequestId());
 
         if (request.isDelete() != null && Boolean.TRUE.equals(request.isDelete())) {
             event.setType("deleted");
@@ -40,7 +49,7 @@ public class ResourceChangedRequestMapper {
                         objectMapper.writeValueAsString(request.registersData());
                 changedResource.setDeletedData(objectMapper.readValue(serialisedDeletedData, Object.class));
             } catch (JsonProcessingException ex) {
-                logger.error(SERDES_ERROR_MSG, ex);
+                LOGGER.error(SERDES_ERROR_MSG, ex, DataMapHolder.getLogMap());
                 throw new InternalServerErrorException(SERDES_ERROR_MSG);
             }
         } else {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,9 @@
 management.endpoints.enabled-by-default=false
 management.endpoints.web.base-path=/
-management.endpoints.web.path-mapping.health=/healthcheck
+management.endpoints.web.path-mapping.health=healthcheck
 management.endpoint.health.show-details=never
 management.endpoint.health.enabled=true
+management.health.mongo.enabled=false
 
 chs.kafka.api.endpoint=${CHS_KAFKA_API_URL:localhost}
 chs.kafka.api.key=${CHS_API_KEY:chsApiKey}

--- a/src/test/java/uk/gov/companieshouse/registers/RegistersApplicationTest.java
+++ b/src/test/java/uk/gov/companieshouse/registers/RegistersApplicationTest.java
@@ -1,13 +1,37 @@
 package uk.gov.companieshouse.registers;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class RegistersApplicationTest {
 
-	@Test
-	void contextLoads() {
-	}
+    @Autowired
+    private MockMvc mockMvc;
 
+    @Test
+    void shouldStartApplication() {
+        Executable executable = () -> RegistersApplication.main(new String[0]);
+        assertDoesNotThrow(executable);
+    }
+
+    @Test
+    void shouldReturn200FromGetHealthEndpoint() throws Exception {
+        this.mockMvc.perform(get("/healthcheck"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string("{\"status\":\"UP\"}"));
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/registers/controller/RegistersControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/registers/controller/RegistersControllerTest.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,15 +36,12 @@ import uk.gov.companieshouse.api.registers.CompanyRegister;
 import uk.gov.companieshouse.api.registers.InternalData;
 import uk.gov.companieshouse.api.registers.InternalRegisters;
 import uk.gov.companieshouse.api.registers.Registers;
-import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.registers.config.ExceptionHandlerConfig;
 import uk.gov.companieshouse.registers.config.WebSecurityConfig;
 import uk.gov.companieshouse.registers.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.registers.model.CompanyRegistersDocument;
 import uk.gov.companieshouse.registers.model.ServiceStatus;
 import uk.gov.companieshouse.registers.service.RegistersService;
-
-import java.util.Optional;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = RegistersController.class)
@@ -57,9 +55,6 @@ class RegistersControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @MockBean
-    private Logger logger;
 
     @MockBean
     private RegistersService registersService;
@@ -78,7 +73,7 @@ class RegistersControllerTest {
     @Test
     @DisplayName("Successful upsert request")
     void upsertCompanyRegisters() throws Exception {
-        when(registersService.upsertCompanyRegisters(any(), any(), any())).thenReturn(ServiceStatus.SUCCESS);
+        when(registersService.upsertCompanyRegisters(any(), any())).thenReturn(ServiceStatus.SUCCESS);
 
         mockMvc.perform(put(URI)
                 .contentType(APPLICATION_JSON)
@@ -93,7 +88,7 @@ class RegistersControllerTest {
     @Test
     @DisplayName("Unauthorised oauth2 upsert request")
     void upsertCompanyRegistersUnauthorisedOauth2() throws Exception {
-        when(registersService.upsertCompanyRegisters(any(), any(), any())).thenReturn(ServiceStatus.SUCCESS);
+        when(registersService.upsertCompanyRegisters(any(), any())).thenReturn(ServiceStatus.SUCCESS);
 
         mockMvc.perform(put(URI)
                 .contentType(APPLICATION_JSON)
@@ -107,7 +102,7 @@ class RegistersControllerTest {
     @Test
     @DisplayName("Unauthorised upsert request")
     void upsertCompanyRegistersUnauthorised() throws Exception {
-        when(registersService.upsertCompanyRegisters(any(), any(), any())).thenReturn(ServiceStatus.SUCCESS);
+        when(registersService.upsertCompanyRegisters(any(), any())).thenReturn(ServiceStatus.SUCCESS);
 
         mockMvc.perform(put(URI)
                 .contentType(APPLICATION_JSON)
@@ -121,7 +116,7 @@ class RegistersControllerTest {
     @Test
     @DisplayName("Server error upsert request")
     void upsertCompanyRegistersServerError() throws Exception {
-        when(registersService.upsertCompanyRegisters(any(), any(), any())).thenReturn(ServiceStatus.SERVER_ERROR);
+        when(registersService.upsertCompanyRegisters(any(), any())).thenReturn(ServiceStatus.SERVER_ERROR);
 
         mockMvc.perform(put(URI)
                 .contentType(APPLICATION_JSON)
@@ -136,7 +131,7 @@ class RegistersControllerTest {
     @Test
     @DisplayName("Client error upsert request")
     void upsertCompanyRegistersClientError() throws Exception {
-        when(registersService.upsertCompanyRegisters(any(), any(), any())).thenReturn(ServiceStatus.CLIENT_ERROR);
+        when(registersService.upsertCompanyRegisters(any(), any())).thenReturn(ServiceStatus.CLIENT_ERROR);
 
         mockMvc.perform(put(URI)
                 .contentType(APPLICATION_JSON)
@@ -188,20 +183,6 @@ class RegistersControllerTest {
         assertEquals(data, objectMapper.readValue(result.getResponse().getContentAsString(), CompanyRegister.class));
     }
 
-//    @Test
-//    @DisplayName("Document not found for get company registers request")
-//    void getCompanyRegistersNotFound() throws Exception {
-//        when(registersService.getCompanyRegisters(any())).thenReturn(Optional.empty());
-//
-//        mockMvc.perform(get(URI)
-//                .contentType(APPLICATION_JSON)
-//                .header("x-request-id", "5342342")
-//                .header("ERIC-Identity", "Test-Identity")
-//                .header("ERIC-Identity-Type", "Key")
-//                .header("ERIC-Authorised-Key-Privileges", "internal-app"))
-//                .andExpect(status().isNotFound());
-//    }
-
     @Test
     @DisplayName("MongoDB is unavailable for get company registers request")
     void getCompanyRegistersMongoUnavailable() throws Exception {
@@ -219,7 +200,7 @@ class RegistersControllerTest {
     @Test
     @DisplayName("Successful delete company registers request")
     void deleteCompanyRegisters() throws Exception {
-        when(registersService.deleteCompanyRegisters(any(), any())).thenReturn(ServiceStatus.SUCCESS);
+        when(registersService.deleteCompanyRegisters(any())).thenReturn(ServiceStatus.SUCCESS);
 
         mockMvc.perform(delete(URI)
                 .contentType(APPLICATION_JSON)
@@ -233,7 +214,7 @@ class RegistersControllerTest {
     @Test
     @DisplayName("Server error delete request")
     void deleteCompanyRegistersServerError() throws Exception {
-        when(registersService.deleteCompanyRegisters(any(), any())).thenReturn(ServiceStatus.SERVER_ERROR);
+        when(registersService.deleteCompanyRegisters(any())).thenReturn(ServiceStatus.SERVER_ERROR);
 
         mockMvc.perform(delete(URI)
                 .contentType(APPLICATION_JSON)
@@ -247,7 +228,7 @@ class RegistersControllerTest {
     @Test
     @DisplayName("Not found delete request")
     void deleteCompanyRegistersNotFound() throws Exception {
-        when(registersService.deleteCompanyRegisters(any(), any())).thenReturn(ServiceStatus.CLIENT_ERROR);
+        when(registersService.deleteCompanyRegisters(any())).thenReturn(ServiceStatus.CLIENT_ERROR);
 
         mockMvc.perform(delete(URI)
                 .contentType(APPLICATION_JSON)

--- a/src/test/java/uk/gov/companieshouse/registers/service/AuthenticationFilterTest.java
+++ b/src/test/java/uk/gov/companieshouse/registers/service/AuthenticationFilterTest.java
@@ -4,24 +4,21 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.logging.Logger;
 
 @ExtendWith(MockitoExtension.class)
 class AuthenticationFilterTest {
 
-    @Mock
-    private Logger logger;
     @Mock
     private HttpServletRequest request;
     @Mock

--- a/src/test/java/uk/gov/companieshouse/registers/service/RegistersApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/registers/service/RegistersApiServiceTest.java
@@ -20,11 +20,11 @@ import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.chskafka.PrivateChangedResourceHandler;
 import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
+import uk.gov.companieshouse.api.http.HttpClient;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.registers.model.ResourceChangedRequest;
 import uk.gov.companieshouse.registers.model.ServiceStatus;
 import uk.gov.companieshouse.registers.util.ResourceChangedRequestMapper;
-import uk.gov.companieshouse.logging.Logger;
 
 @ExtendWith(MockitoExtension.class)
 class RegistersApiServiceTest {
@@ -36,6 +36,9 @@ class RegistersApiServiceTest {
     private InternalApiClient internalApiClient;
 
     @Mock
+    private HttpClient httpClient;
+
+    @Mock
     private PrivateChangedResourceHandler privateChangedResourceHandler;
 
     @Mock
@@ -43,9 +46,6 @@ class RegistersApiServiceTest {
 
     @Mock
     private ApiResponse<Void> response;
-
-    @Mock
-    private Logger logger;
 
     @Mock
     private Supplier<String> dateGenerator;
@@ -66,6 +66,7 @@ class RegistersApiServiceTest {
     @DisplayName("Test should successfully invoke chs-kafka-api")
     void invokeChsKafkaApi() throws ApiErrorResponseException {
         when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.getHttpClient()).thenReturn(httpClient);
         when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
         when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(changedResourcePost);
         when(changedResourcePost.execute()).thenReturn(response);
@@ -116,6 +117,7 @@ class RegistersApiServiceTest {
 
     private void setupExceptionScenario(int statusCode, String statusMessage) throws ApiErrorResponseException {
         when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.getHttpClient()).thenReturn(httpClient);
         when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
         when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(changedResourcePost);
         when(mapper.mapChangedResource(resourceChangedRequest)).thenReturn(changedResource);

--- a/src/test/java/uk/gov/companieshouse/registers/util/RegistersMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/registers/util/RegistersMapperTest.java
@@ -1,20 +1,5 @@
 package uk.gov.companieshouse.registers.util;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.api.registers.*;
-import uk.gov.companieshouse.registers.model.CompanyRegistersDocument;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -28,6 +13,31 @@ import static uk.gov.companieshouse.api.registers.RegisterListSecretaries.Regist
 import static uk.gov.companieshouse.api.registers.RegisterListUsualResidentialAddress.RegisterTypeEnum.USUAL_RESIDENTIAL_ADDRESS;
 import static uk.gov.companieshouse.api.registers.RegisteredItems.RegisterMovedToEnum.PUBLIC_REGISTER;
 import static uk.gov.companieshouse.api.registers.RegisteredItems.RegisterMovedToEnum.UNSPECIFIED_LOCATION;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.registers.CompanyRegister;
+import uk.gov.companieshouse.api.registers.InternalData;
+import uk.gov.companieshouse.api.registers.InternalRegisters;
+import uk.gov.companieshouse.api.registers.LinksType;
+import uk.gov.companieshouse.api.registers.RegisterListDirectors;
+import uk.gov.companieshouse.api.registers.RegisterListLLPMembers;
+import uk.gov.companieshouse.api.registers.RegisterListLLPUsualResidentialAddress;
+import uk.gov.companieshouse.api.registers.RegisterListMembers;
+import uk.gov.companieshouse.api.registers.RegisterListSecretaries;
+import uk.gov.companieshouse.api.registers.RegisterListUsualResidentialAddress;
+import uk.gov.companieshouse.api.registers.RegisteredItems;
+import uk.gov.companieshouse.api.registers.Registers;
+import uk.gov.companieshouse.registers.model.CompanyRegistersDocument;
 
 @ExtendWith(MockitoExtension.class)
 public class RegistersMapperTest {

--- a/src/test/java/uk/gov/companieshouse/registers/util/ResourceChangedRequestMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/registers/util/ResourceChangedRequestMapperTest.java
@@ -4,37 +4,44 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.internal.matchers.Any;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
 import uk.gov.companieshouse.api.registers.CompanyRegister;
+import uk.gov.companieshouse.registers.logging.DataMapHolder;
 import uk.gov.companieshouse.registers.model.ResourceChangedRequest;
 
 @ExtendWith(MockitoExtension.class)
 class ResourceChangedRequestMapperTest {
 
     private static final String EXPECTED_CONTEXT_ID = "35234234";
-    private static final String DATE = "date";
+    private static final Instant DATE = Instant.parse("2024-09-30T12:00:00.123456Z");
+    private static final String DATE_STRING = "2024-09-30T12:00:00";
 
     @Mock
-    private Supplier<String> timestampGenerator;
+    private Supplier<Instant> timestampGenerator;
 
     @Mock
     private ObjectMapper objectMapper;
 
     @InjectMocks
     private ResourceChangedRequestMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        DataMapHolder.initialise(EXPECTED_CONTEXT_ID);
+    }
 
     @ParameterizedTest
     @MethodSource("resourceChangedScenarios")
@@ -56,29 +63,29 @@ class ResourceChangedRequestMapperTest {
     static Stream<ResourceChangedTestArgument> resourceChangedScenarios() {
         return Stream.of(
                 ResourceChangedTestArgument.builder()
-                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "12345678", null, false))
+                        .withRequest(new ResourceChangedRequest("12345678", null, false))
                         .withContextId(EXPECTED_CONTEXT_ID)
                         .withResourceUri("company/12345678/registers")
                         .withResourceKind("registers")
                         .withEventType("changed")
-                        .withEventPublishedAt(DATE)
+                        .withEventPublishedAt(DATE_STRING)
                         .build(),
                 ResourceChangedTestArgument.builder()
-                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "12345678", null, null))
+                        .withRequest(new ResourceChangedRequest("12345678", null, null))
                         .withContextId(EXPECTED_CONTEXT_ID)
                         .withResourceUri("company/12345678/registers")
                         .withResourceKind("registers")
                         .withEventType("changed")
-                        .withEventPublishedAt(DATE)
+                        .withEventPublishedAt(DATE_STRING)
                         .build(),
                 ResourceChangedTestArgument.builder()
-                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "12345678", new CompanyRegister(), true))
+                        .withRequest(new ResourceChangedRequest("12345678", new CompanyRegister(), true))
                         .withContextId(EXPECTED_CONTEXT_ID)
                         .withResourceUri("company/12345678/registers")
                         .withResourceKind("registers")
                         .withEventType("deleted")
                         .withDeletedData(new CompanyRegister())
-                        .withEventPublishedAt(DATE)
+                        .withEventPublishedAt(DATE_STRING)
                         .build()
         );
     }


### PR DESCRIPTION
* Improves logging by adding a request logging filter, propagated request ID and logmap in each message.
* Fixes code smells.
* Standardises published_at timestamp format by rounding to seconds and removing UTC indicator, 'Z'.

[DSND-2870](https://companieshouse.atlassian.net/browse/DSND-2870)

[DSND-2870]: https://companieshouse.atlassian.net/browse/DSND-2870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ