### PR TITLE
ASM-805- dependency upgrades to resolve latest vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 		<spring.boot.version>3.5.4</spring.boot.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<tomcat-embed-core.version>11.0.11</tomcat-embed-core.version>
 
 		<!-- tests -->
 		<maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
@@ -31,7 +32,7 @@
 
 		<!-- internal -->
 		<structured-logging.version>3.0.24</structured-logging.version>
-		<private-api-sdk-java.version>4.0.258</private-api-sdk-java.version>
+		<private-api-sdk-java.version>4.0.360</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>3.0.11</api-sdk-manager-java-library.version>
 		<api-helper-java-library.version>3.0.1</api-helper-java-library.version>
     <api-security-java.version>2.0.8</api-security-java.version>
@@ -123,6 +124,12 @@
 					<artifactId>commons-collections</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<!--CVE-2025-48989(7.5) transitive needing update from parent dependency api-sdk-manager  -->
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-websocket</artifactId>
+			<version>${tomcat-embed-core.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>uk.gov.companieshouse</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<java.version>21</java.version>
 
 		<maven-build-helper-plugin.version>3.6.0</maven-build-helper-plugin.version>
-		<spring.boot.version>3.4.1</spring.boot.version>
+		<spring.boot.version>3.5.4</spring.boot.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 
@@ -32,7 +32,7 @@
 		<!-- internal -->
 		<structured-logging.version>3.0.24</structured-logging.version>
 		<private-api-sdk-java.version>4.0.258</private-api-sdk-java.version>
-		<api-sdk-manager-java-library.version>3.0.6</api-sdk-manager-java-library.version>
+		<api-sdk-manager-java-library.version>3.0.11</api-sdk-manager-java-library.version>
 		<api-helper-java-library.version>3.0.1</api-helper-java-library.version>
     <api-security-java.version>2.0.8</api-security-java.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,12 @@
 			<artifactId>tomcat-embed-core</artifactId>
 			<version>${tomcat-embed-core.version}</version>
 		</dependency>
+		<dependency>
+			<!--Also for CVE-2025-48989(7.5) -->
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-websocket</artifactId>
+			<version>${tomcat-embed-core.version}</version>
+		</dependency>
 		<!-- CVE-2025-48924(5.3) needing update from parent dependency private-api-sdk -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<tomcat-embed-core.version>11.0.11</tomcat-embed-core.version>
+		<commons-lang3.version>3.18.0</commons-lang3.version>
 
 		<!-- tests -->
 		<maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
@@ -126,12 +127,6 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<!--CVE-2025-48989(7.5) transitive needing update from parent dependency api-sdk-manager  -->
-			<groupId>org.apache.tomcat.embed</groupId>
-			<artifactId>tomcat-embed-websocket</artifactId>
-			<version>${tomcat-embed-core.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>uk.gov.companieshouse</groupId>
 			<artifactId>api-helper-java</artifactId>
 			<version>${api-helper-java-library.version}</version>
@@ -182,6 +177,19 @@
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<!-- transitive dependencies added to resolve vulnerabilities in parent dependencies -->
+		<dependency>
+			<!--CVE-2025-48989(7.5) transitive needing update from parent dependency private-api-sdk  -->
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-core</artifactId>
+			<version>${tomcat-embed-core.version}</version>
+		</dependency>
+		<!-- CVE-2025-48924(5.3) needing update from parent dependency private-api-sdk -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>${commons-lang3.version}</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Resolves [ASM-805](https://companieshouse.atlassian.net/browse/ASM-805)

Bump versions and add transitive dependency upgrades to:

- spring.boot
- tomcat-embed-core
- tomcat-embed-websocket
- commons-lang3
- private-api-sdk-java
- api-sdk-manager-java


[ASM-805]: https://companieshouse.atlassian.net/browse/ASM-805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ